### PR TITLE
Add guild restriction feature and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A Discord bot that automatically assigns roles to new users who join your server
 - **Permission Checks**: Ensures proper permissions before role assignment
 - **Error Handling**: Comprehensive error handling and user feedback
 - **Persistent Storage**: Saves role configurations across bot restarts
+- **Guild Restriction**: If GUILD_ID is set in .env, bot will only stay in that specific server
 
 ## Commands
 
@@ -46,7 +47,7 @@ npm install
    ```env
    DISCORD_TOKEN=your_bot_token_here
    CLIENT_ID=your_client_id_here
-   GUILD_ID=your_guild_id_here  # Optional: for faster command registration during development
+   GUILD_ID=your_guild_id_here  # Optional: restricts bot to specific server + faster command registration
    ```
 
 ### 4. Invite the Bot to Your Server
@@ -90,6 +91,22 @@ All commands require the "Manage Roles" permission by default. Only users with t
 - View current join role configuration
 - Remove join role assignments
 
+### Guild Restriction (Optional)
+
+If you want to restrict the bot to only work in a specific server:
+
+1. **Set GUILD_ID**: Add your server's ID to the `.env` file
+2. **Automatic Restriction**: The bot will:
+   - Leave any existing servers that don't match the GUILD_ID on startup
+   - Immediately leave any new servers it's invited to that don't match
+   - Only register commands in the specified server (faster than global registration)
+
+To find your server's ID:
+1. Enable Developer Mode in Discord (User Settings > Advanced > Developer Mode)
+2. Right-click your server name and select "Copy Server ID"
+
+**Note**: If GUILD_ID is not set, the bot will work in all servers it's invited to.
+
 ## Usage
 
 1. **Set a Join Role**: Use `/set-join-role` and select the role you want new members to receive
@@ -102,32 +119,33 @@ All commands require the "Manage Roles" permission by default. Only users with t
 ```
 AP Bot/
 ├── src/
-│   ├── commands/              # Command handlers
-│   │   ├── index.js          # Command router
-│   │   ├── setJoinRole.js    # Set join role command
-│   │   ├── getJoinRole.js    # Get join role command
-│   │   └── removeJoinRole.js # Remove join role command
-│   ├── config/               # Configuration files
-│   │   ├── client.js         # Discord client configuration
-│   │   └── commands.js       # Command definitions
-│   ├── events/               # Event handlers
-│   │   ├── index.js          # Event registration
-│   │   ├── ready.js          # Bot ready event
-│   │   ├── interactionCreate.js # Command interaction handling
-│   │   ├── guildMemberAdd.js # New member join handling
-│   │   └── error.js          # Error handling
-│   └── utils/                # Utility functions
-│       ├── embeds.js         # Discord embed helpers
-│       ├── joinRoles.js      # Role management utilities
-│       └── permissions.js    # Permission validation
-├── index.js                  # Main entry point
-├── package.json              # Node.js dependencies
-├── .env.example              # Environment variable template
-├── .env                      # Your bot configuration (not in git)
-├── .gitignore               # Git ignore file
-├── join-roles.json          # Persistent storage for role configurations
-├── validate-setup.js        # Setup validation script
-└── README.md                # This file
+│   ├── commands/                       # Command handlers
+│   │   ├── index.js                    # Command router
+│   │   ├── setJoinRole.js              # Set join role command
+│   │   ├── getJoinRole.js              # Get join role command
+│   │   └── removeJoinRole.js           # Remove join role command
+│   ├── config/                         # Configuration files
+│   │   ├── client.js                   # Discord client configuration
+│   │   └── commands.js                 # Command definitions
+│   ├── events/                         # Event handlers
+│   │   ├── index.js                    # Event registration
+│   │   ├── ready.js                    # Bot ready event
+│   │   ├── interactionCreate.js        # Command interaction handling
+│   │   ├── guildMemberAdd.js           # New member join handling
+│   │   └── error.js                    # Error handling
+│   ├── roles/                          # Role Management
+│   │   └── join-roles.json             # Persistent storage for role configurations
+│   └── utils/                          # Utility functions
+│       ├── embeds.js                   # Discord embed helpers
+│       ├── joinRoles.js                # Role management utilities
+│       └── permissions.js              # Permission validation
+├── index.js                            # Main entry point (run with pm2 start)
+├── package.json                        # Node.js dependencies
+├── .env.example                        # Environment variable template
+├── .env                                # Your bot configuration (not in git)
+├── .gitignore                          # Git ignore file
+├── validate-setup.js                   # Setup validation script
+└── README.md                           # This file
 ```
 
 ## Project Architecture
@@ -153,6 +171,9 @@ The bot is organized into separate concerns for better maintainability:
 - **Embeds**: Helper functions for creating Discord embeds
 - **Join Roles**: Role management and persistence utilities
 - **Permissions**: Permission validation and role hierarchy checks
+
+### **Roles** (`src/roles/`)
+- Persistent storage for role configurations
 
 ## Troubleshooting
 

--- a/src/events/guildCreate.js
+++ b/src/events/guildCreate.js
@@ -1,0 +1,34 @@
+const { Events } = require('discord.js');
+
+/**
+ * Handle guild create events (bot joins a new server)
+ * @param {Guild} guild - The guild the bot joined
+ */
+async function handleGuildCreate(guild) {
+    console.log(`🆕 Joined new guild: ${guild.name} (${guild.id})`);
+    
+    // If GUILD_ID is set and this guild doesn't match, leave immediately
+    if (process.env.GUILD_ID && guild.id !== process.env.GUILD_ID) {
+        try {
+            console.log(`🚪 Guild ${guild.name} (${guild.id}) doesn't match configured GUILD_ID. Leaving immediately...`);
+            await guild.leave();
+            console.log(`✅ Successfully left guild: ${guild.name}`);
+        } catch (error) {
+            console.error(`❌ Error leaving guild ${guild.name}:`, error);
+        }
+    } else if (process.env.GUILD_ID) {
+        console.log(`✅ Guild ${guild.name} matches configured GUILD_ID. Staying in guild.`);
+    } else {
+        console.log(`ℹ️ No GUILD_ID configured. Staying in guild: ${guild.name}`);
+    }
+}
+
+/**
+ * Register the guild create event
+ * @param {Client} client - Discord client
+ */
+function registerGuildCreateEvent(client) {
+    client.on(Events.GuildCreate, handleGuildCreate);
+}
+
+module.exports = { registerGuildCreateEvent };

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -1,6 +1,7 @@
 const { registerReadyEvent } = require('./ready');
 const { registerInteractionCreateEvent } = require('./interactionCreate');
 const { registerGuildMemberAddEvent } = require('./guildMemberAdd');
+const { registerGuildCreateEvent } = require('./guildCreate');
 const { registerErrorEvents } = require('./error');
 
 /**
@@ -11,6 +12,7 @@ function registerAllEvents(client) {
     registerReadyEvent(client);
     registerInteractionCreateEvent(client);
     registerGuildMemberAddEvent(client);
+    registerGuildCreateEvent(client);
     registerErrorEvents(client);
     
     console.log('✅ All events registered');


### PR DESCRIPTION
This pull request introduces a new feature to restrict the bot to a specific server using the `GUILD_ID` environment variable. It includes updates to documentation, new event handling logic, and structural changes to the project for better organization. Below are the key changes grouped by theme:

### New Feature: Guild Restriction

* **Documentation Updates**: Added details in `README.md` on how to use the `GUILD_ID` variable to restrict the bot to a specific server. This includes instructions for setting the `GUILD_ID`, its effects on bot behavior, and how to find a server's ID. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-R50) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R94-R109)
* **Event Handling**: Implemented a new `guildCreate` event handler in `src/events/guildCreate.js` to make the bot leave servers that do not match the configured `GUILD_ID`. This ensures the bot only operates in the specified server.

### Codebase Enhancements

* **Event Registration**: Updated `src/events/index.js` to register the new `guildCreate` event, ensuring it is included in the bot's event lifecycle. [[1]](diffhunk://#diff-2d4a0d6948566e5e6e7aa581da296f1d4e73bdd4c32570cdd53b8395ccd89a37R4) [[2]](diffhunk://#diff-2d4a0d6948566e5e6e7aa581da296f1d4e73bdd4c32570cdd53b8395ccd89a37R15)

### Project Structure

* **Role Management**: Moved `join-roles.json` to a dedicated `src/roles/` directory for better organization of role-related files. Updated the project structure documentation in `README.md` accordingly. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R136-L128) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R175-R177)